### PR TITLE
bump shiny version to 1.5.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ numpy==2.4.2
 pandas==3.0.0
 plotly==6.5.2
 python-dotenv==1.2.2
-shiny==1.4.0
+shiny==1.5.1
 shinywidgets==0.7.1
 uvicorn==0.40.0
 


### PR DESCRIPTION
- Bumped shiny version to 1.5.1 for compatibility with querychat==0.5.1